### PR TITLE
Updated Kotlin to version 2.2.0 and updated dependencies

### DIFF
--- a/exampleApp/build.gradle.kts
+++ b/exampleApp/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
     
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "composeApp"
+        outputModuleName.set("composeApp")
         browser {
             val rootDirPath = project.rootDir.path
             val projectDirPath = project.projectDir.path
@@ -74,6 +74,10 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
         }
+    }
+
+    compilerOptions {
+        freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,6 @@ kotlin.code.style=official
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.compileSdk=34
-android.targetSdk=34
-android.minSdk=24
 jvm.version=17
 
 #MPP

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,17 @@
 [versions]
-agp = "8.7.2"
-kotlin = "2.1.0"
-kotlinDateTime = "0.6.2"
-kotlinCompatibility = "1.5.14"
-compose-multiplatform = "1.7.3"
-androidx-lifecycle = "2.8.4"
-androidx-material = "1.12.0"
+agp = "8.11.0"
+kotlin = "2.2.0"
+kotlinDateTime = "0.7.1"
+compose-multiplatform = "1.8.2"
+androidx-lifecycle = "2.9.1"
 androidx-activityCompose = "1.10.1"
-kotlinx-coroutines = "1.10.1"
-android-compileSdk = "35"
+kotlinx-coroutines = "1.10.2"
+android-compileSdk = "36"
 android-minSdk = "24"
-android-targetSdk = "35"
+android-targetSdk = "36"
 
 [libraries]
 kotlin-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinDateTime" }
-androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Nov 27 21:35:08 AMT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
@@ -6,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
 
-    id("com.vanniktech.maven.publish") version "0.30.0"
+    id("com.vanniktech.maven.publish") version "0.33.0"
     id("signing")
 }
 
@@ -26,7 +25,7 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "kmm-logging"
+        outputModuleName.set("kmm-logging")
         browser {
             val rootDirPath = project.rootDir.path
             val projectDirPath = project.projectDir.path
@@ -56,22 +55,22 @@ kotlin {
             }
         }
     }
+
+    compilerOptions {
+        freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
+    }
 }
 
 android {
     namespace = "com.lynxal.logging"
-    compileSdk = (findProperty("android.compileSdk") as String).toInt()
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
     defaultConfig {
-        minSdk = (findProperty("android.minSdk") as String).toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
     }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.kotlinCompatibility.get()
     }
 
     kotlin {
@@ -80,10 +79,10 @@ android {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 
-    coordinates("com.lynxal.logging", "logging", "0.0.5")
+    coordinates("com.lynxal.logging", "logging", "0.0.6")
     pom {
         name.set("KMM Logging")
         description.set("A lightweight and flexible logging library for Kotlin Multiplatform Mobile (KMM) projects. It provides platform-specific logging implementations for Android and iOS, with an easy-to-use API and customizable log levels. Designed to integrate seamlessly into KMM applications.")

--- a/logging/src/commonMain/kotlin/com/lynxal/logging/LogDetails.kt
+++ b/logging/src/commonMain/kotlin/com/lynxal/logging/LogDetails.kt
@@ -1,7 +1,8 @@
 package com.lynxal.logging
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
+
 
 data class LogDetails(
     val logLevel: LogLevel,
@@ -10,7 +11,7 @@ data class LogDetails(
     val payload: Map<String, String> = emptyMap(),
     val timestamp: Instant = Clock.System.now()
 ) {
-    data class Builder internal constructor(
+    data class Builder(
         var message: String = "",
         var cause: Throwable? = null,
         var payload: Map<String, String> = emptyMap()


### PR DESCRIPTION
The Kotlin version was updated to 2.2.0.
Other dependencies were also updated, including AGP, Kotlin DateTime, Compose Multiplatform, AndroidX Lifecycle, and KotlinX Coroutines. The Gradle version was updated to 8.13.
The Android compile and target SDK versions were updated to 36. The `moduleName` property in the WasmJs configuration was replaced with `outputModuleName.set()`. The library version was updated to 0.0.6.
The `kotlinx.datetime.Clock` and `kotlinx.datetime.Instant` were replaced with `kotlin.time.Clock` and `kotlin.time.Instant` respectively. Code Cleanup